### PR TITLE
Get CI working for python 3.11 and 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: libais CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -19,32 +19,25 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10-dev']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-      - name: Add required sources and pkgs
-        run: |
-          sudo add-apt-repository --update --yes 'deb http://archive.ubuntu.com/ubuntu/ bionic main universe'
-          sudo apt-get install gcc-6 g++-6
-
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: 'x64'
 
       - name: Before install
         run: |
-          mkdir --parents --verbose ${{ env.PIP_WHEEL_DIR }}
-          pip install setuptools --upgrade
+          python -m pip install --upgrade pip
           pip install pytest --upgrade
 
       - name: Install
-        run: CC=g++-6 pip install .\[tests\] --upgrade
+        run: pip install .\[tests\] --upgrade
         
       - name: Script
         run: |
-          (cd src && CC=gcc-6 CXX=g++-6 make -f Makefile-custom -j 4 test)
+          (cd src && make -f Makefile-custom -j 4 test)
           py.test ais test --cov=ais --cov-report term-missing

--- a/test/compatibility/gpsd_test.py
+++ b/test/compatibility/gpsd_test.py
@@ -32,6 +32,14 @@ class SingleMessageTestsTest(unittest.TestCase):
   def setUp(self):
     self.mangle = ais.compatibility.gpsd.Mangler()
 
+  def assertDictContainsSubset2(self, actual, expected):
+      # assertDictContainsSubset was deprecated because of incorrect arg order.
+      # This method has the correct order.
+      self.assertIsInstance(expected, dict)
+      self.assertIsInstance(actual, dict)
+      for key, value in expected.items():
+          self.assertEqual(actual[key], value, 'kv: %s, %s' % (key, value))
+
   def testMsg1(self):
     fields = '!AIVDM,1,1,,B,169A91O005KbT4gUoUl9d;5j0D0U,0*2D'.split(',')
     decoded = ais.decode(fields[5], int(fields[6][0]))
@@ -50,7 +58,7 @@ class SingleMessageTestsTest(unittest.TestCase):
         'second': 57,
         'maneuver': 0,
         'raim': False}
-    self.assertDictContainsSubset(expected, mangled)
+    self.assertDictContainsSubset2(mangled, expected)
 
     # Float values will not match, so just test existence.
     for field in ('lat', 'lon'):
@@ -69,7 +77,7 @@ class SingleMessageTestsTest(unittest.TestCase):
         'shiptype': 204,
         'shiptype_text': '204 - Unknown',
         'type': 5}
-    self.assertDictContainsSubset(expected, mangled)
+    self.assertDictContainsSubset2(mangled, expected)
 
   def testTimestamps(self):
     msg = {
@@ -89,7 +97,7 @@ class SingleMessageTestsTest(unittest.TestCase):
         'timestamp': '2015-05-15T09:27:23Z',
         'tagblock_timestamp': '2015-05-15T09:27:23.000000Z'
         }
-    self.assertDictContainsSubset(expected, mangled)
+    self.assertDictContainsSubset2(mangled, expected)
 
 
 class StreamingTest(unittest.TestCase):

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -33,8 +33,8 @@ class Ais6Decoders(unittest.TestCase):
   def testDecodeUnknownMessage6(self):
     # !AIVDM,1,1,,B,6B?n;be:cbapalgc;i6?Ow4,2*4A'
     # TODO(schwehr): Expose the C++ Python exception to Python.
-    self.assertRaisesRegexp(ais.DecodeError, '6:669:11',
-                            ais.decode, '6B?n;be:cbapalgc;i6?Ow4', 2)
+    self.assertRaisesRegex(ais.DecodeError, '6:669:11',
+                           ais.decode, '6B?n;be:cbapalgc;i6?Ow4', 2)
 
 if __name__=='__main__':
   unittest.main()


### PR DESCRIPTION
* Update the github CI to include python 3.11 and 3.12
* Fix unit tests that break in python 3.12 because of deprecated functionality in UnitTest