### PR TITLE
Best effort decoding for type 1, 2, 3 and 5 when there are extra bits

### DIFF
--- a/src/libais/ais.cpp
+++ b/src/libais/ais.cpp
@@ -68,9 +68,9 @@ const char * const AIS_STATUS_STRINGS[AIS_STATUS_NUM_CODES] = {
   "AIS_ERR_BAD_SUB_SUB_MSG",
 };
 
-AisMsg::AisMsg(const char *nmea_payload, const size_t pad)
+AisMsg::AisMsg(const char *nmea_payload, const size_t pad, const bool best_effort)
     : message_id(0), repeat_indicator(0), mmsi(0), status(AIS_UNINITIALIZED),
-      num_chars(0), num_bits(0), bits() {
+      best_effort(best_effort), num_chars(0), num_bits(0), bits() {
   assert(nmea_payload);
   assert(pad < 6);
 
@@ -102,6 +102,14 @@ bool AisMsg::CheckStatus() const {
             << std::endl;
 #endif
   return false;
+}
+
+bool AisMsg::CheckNumBits(size_t expected_num_bits) {
+  bool ok = best_effort ? num_bits >= expected_num_bits : num_bits == expected_num_bits;
+  if (!ok) {
+    status = AIS_ERR_BAD_BIT_COUNT;
+  }
+  return ok;
 }
 
 AisPoint::AisPoint() : lng_deg(0), lat_deg(0) {

--- a/src/libais/ais.h
+++ b/src/libais/ais.h
@@ -444,17 +444,21 @@ class AisMsg {
 
  protected:
   AIS_STATUS status;  // AIS_OK or error code
+  bool best_effort = false;  // Use best effort to parse
   int num_chars;  // Number of characters in the nmea_payload.
   size_t num_bits;  // Number of bits in the nmea_payload.
   AisBitset bits;  // The bitset that was constructed out of the nmea_payload.
 
   AisMsg() : status(AIS_UNINITIALIZED), num_chars(0), num_bits(0), bits() {}
-  AisMsg(const char *nmea_payload, const size_t pad);
+  AisMsg(const char *nmea_payload, const size_t pad, const bool best_effort = false);
 
   // Returns true if the msg is in a good state "so far", i.e. either AIS_OK or
   // AIS_UNINITIALIZED.
   bool CheckStatus() const;
+  bool CheckNumBits(size_t expected_num_bits);
 };
+
+
 
 // TODO(schwehr): factor out commstate from all messages?
 class Ais1_2_3 : public AisMsg {
@@ -504,7 +508,7 @@ class Ais1_2_3 : public AisMsg {
   bool keep_flag_valid;
   bool keep_flag;  // 3.3.7.3.2 Annex 2 ITDMA.  Table 20
 
-  Ais1_2_3(const char *nmea_payload, const size_t pad);
+  Ais1_2_3(const char *nmea_payload, const size_t pad, const bool best_effort=false);
 };
 ostream& operator<< (ostream &o, const Ais1_2_3 &msg);
 
@@ -569,7 +573,7 @@ class Ais5 : public AisMsg {
   int dte;
   int spare;
 
-  Ais5(const char *nmea_payload, const size_t pad);
+  Ais5(const char *nmea_payload, const size_t pad, const bool best_effort=false);
 };
 ostream& operator<< (ostream &o, const Ais5 &msg);
 

--- a/src/libais/ais1_2_3.cpp
+++ b/src/libais/ais1_2_3.cpp
@@ -8,8 +8,8 @@ using std::abs;
 
 namespace libais {
 
-Ais1_2_3::Ais1_2_3(const char *nmea_payload, const size_t pad)
-    : AisMsg(nmea_payload, pad), nav_status(0), rot_over_range(false),
+Ais1_2_3::Ais1_2_3(const char *nmea_payload, const size_t pad, const bool best_effort)
+    : AisMsg(nmea_payload, pad, best_effort), nav_status(0), rot_over_range(false),
       rot_raw(0), rot(0.0), sog(0.0), position_accuracy(0),
       cog(0.0), true_heading(0), timestamp(0), special_manoeuvre(0), spare(0),
       raim(false), sync_state(0),
@@ -21,11 +21,7 @@ Ais1_2_3::Ais1_2_3(const char *nmea_payload, const size_t pad)
       slot_increment_valid(false), slot_increment(0),
       slots_to_allocate_valid(false), slots_to_allocate(0),
       keep_flag_valid(false), keep_flag(false) {
-  if (!CheckStatus()) {
-    return;
-  }
-  if (pad != 0 || num_chars != 28) {
-    status = AIS_ERR_BAD_BIT_COUNT;
+  if (!CheckStatus() || !CheckNumBits(168)) {
     return;
   }
 

--- a/src/libais/ais5.cpp
+++ b/src/libais/ais5.cpp
@@ -4,16 +4,12 @@
 
 namespace libais {
 
-Ais5::Ais5(const char *nmea_payload, const size_t pad)
-    : AisMsg(nmea_payload, pad), ais_version(0), imo_num(0),
+Ais5::Ais5(const char *nmea_payload, const size_t pad, const bool best_effort)
+    : AisMsg(nmea_payload, pad, best_effort), ais_version(0), imo_num(0),
       type_and_cargo(0), dim_a(0), dim_b(0), dim_c(0), dim_d(0),
       fix_type(0), eta_month(0), eta_day(0), eta_hour(0), eta_minute(0),
       draught(0.0), dte(0), spare(0) {
-  if (!CheckStatus()) {
-    return;
-  }
-  if (pad != 2 || num_chars != 71) {
-    status = AIS_ERR_BAD_BIT_COUNT;
+  if (!CheckStatus() || !CheckNumBits(424)) {
     return;
   }
 

--- a/test/test_best_effort.py
+++ b/test/test_best_effort.py
@@ -1,0 +1,21 @@
+import unittest
+import ais
+
+class BestEffortTest(unittest.TestCase):
+
+    def testDecodeWithExtraBits(self):
+        messages = [
+            (1, '181:Kjh01ewHFRPDK1s3IRcn06sd0', 0),  # extra char
+            (1, '181:Kjh01ewHFRPDK1s3IRcn06sd0', 2),  # extra char, wrong pad, 4 extra bits
+            (5, '533uwnT00000uCCSS00MD5@Dl4h400000080001c8h<25uAn00Q1C1VRBS0000000000000', 0),  # wrong pad
+        ]
+        for id, body, pad in messages:
+            # default value for best_effort is False, so messages with extra bits should fail
+            with self.assertRaises(ais.DecodeError):
+                _ = ais.decode(body, pad)
+
+            # Set best_effort to True and now it should succeed
+            best_effort = True
+            msg = ais.decode(body, pad, best_effort)
+            self.assertEqual(id, msg['id'])
+


### PR DESCRIPTION
Add an optional parameter `best_effort` to ais.decode() which indicates whether to allow relaxed testing for the bitcount for  some VDM message types.

For type 1, 2, 3, and 5, setting `best_effort` to True will allow parsing of messages that have more bits than are expected.  This includes cases where there are extra characters at the end of the body, or in the case of type 5, where the padding value should be `2`, setting this flag will allow successful decoding when the pad value is set to `0`.  The extra bits are ignored.

The default value for `best_effort` is False, to preserve backward compatibility

