### PR TITLE
change version number for internal release from the fork

### DIFF
--- a/ais/__init__.py
+++ b/ais/__init__.py
@@ -10,4 +10,4 @@ from ais.io import open
 from ais.io import NmeaFile
 
 __license__ = 'Apache 2.0'
-__version__ = '0.17'
+__version__ = '0.17+gfw.0.0.1'


### PR DESCRIPTION
Set a new version number using a "build metadata" element to provide a new GFW version for internal use but also maintain the libais version where we made the fork