### PR TITLE
Remove all references to six

### DIFF
--- a/ais/io.py
+++ b/ais/io.py
@@ -70,8 +70,6 @@
 import codecs
 import sys
 
-import six
-
 import ais.nmea_queue
 
 
@@ -100,7 +98,7 @@ def open(name, mode='r', **kwargs):
 
   if name == '-':
     fobj = sys.stdin
-  elif isinstance(name, six.string_types):
+  elif isinstance(name, str):
     fobj = codecs.open(name, **kwargs)
   elif hasattr(name, 'close') and \
           (hasattr(name, 'next') or hasattr(name, '__next__')):

--- a/ais/nmea_queue.py
+++ b/ais/nmea_queue.py
@@ -7,21 +7,21 @@ from ais import nmea
 from ais import tag_block
 from ais import uscg
 from ais import vdm
-import six.moves.queue as Queue
+import queue
 
 
 class Error(Exception):
   pass
 
 
-def GetOrNone(queue):
+def GetOrNone(_queue):
   try:
-    return queue.get(block=False)
-  except Queue.Empty:
+    return _queue.get(block=False)
+  except queue.Empty:
     return
 
 
-class NmeaQueue(Queue.Queue):
+class NmeaQueue(queue.Queue):
   # pylint: disable=line-too-long
   r"""Process mixed text, bare NMEA or NMEA with TAG BLOCK or USCG metadata.
 
@@ -109,7 +109,7 @@ class NmeaQueue(Queue.Queue):
     self.tagb_queue = tag_block.TagQueue()
     self.uscg_queue = uscg.UscgQueue()
     self.line_num = 0
-    Queue.Queue.__init__(self)
+    queue.Queue.__init__(self)
 
   def put(self, line, line_num=None):
     """Add a line to the queue.
@@ -145,10 +145,10 @@ class NmeaQueue(Queue.Queue):
 
     if msg:
       msg['line_type'] = line_type
-      Queue.Queue.put(self, msg)
+      queue.Queue.put(self, msg)
 
   def GetOrNone(self):
     try:
       return self.get(block=False)
-    except Queue.Empty:
+    except queue.Empty:
       return

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
 
   ext_modules=[AIS_MODULE],
   packages=find_packages(exclude=['test']),
-  install_requires=['six'],
+  install_requires=[],
   extras_require={
       'tests': tests_require,
   },

--- a/test/compatibility/gpsd_test.py
+++ b/test/compatibility/gpsd_test.py
@@ -11,7 +11,6 @@ import json
 import os
 import re
 import subprocess
-import six
 from .. import testutils
 
 known_problems = {
@@ -123,10 +122,10 @@ class StreamingTest(unittest.TestCase):
 
     try:
       while True:
-        gmsg = six.advance_iterator(g)
-        amsg = six.advance_iterator(a)
+        gmsg = next(g)
+        amsg = next(a)
         while amsg['type'] != gmsg['type']:
-          amsg = six.advance_iterator(a)
+          amsg = next(a)
 
         if gmsg['type'] in known_problems:
           for key in known_problems[gmsg['type']]:
@@ -189,10 +188,10 @@ class TestActualGPSDCompatibility(unittest.TestCase):
 
       try:
         while True:
-          gmsg = six.advance_iterator(g)
-          amsg = six.advance_iterator(a)
+          gmsg = next(g)
+          amsg = next(a)
           while amsg['type'] != gmsg['type']:
-            amsg = six.advance_iterator(a)
+            amsg = next(a)
 
           if gmsg['type'] in known_problems:
             for key in known_problems[gmsg['type']]:

--- a/test/io_test.py
+++ b/test/io_test.py
@@ -6,7 +6,7 @@ import sys
 import ais
 
 import pytest
-from six.moves import StringIO
+from io import StringIO
 
 
 def test_open_right_object(typeexamples_nmea_path):

--- a/test/nmea_queue_test.py
+++ b/test/nmea_queue_test.py
@@ -4,8 +4,7 @@ import contextlib
 import unittest
 
 import pytest
-import six
-from six.moves import StringIO
+from io import StringIO
 
 import ais
 from ais import nmea
@@ -273,10 +272,10 @@ class NmeaQueueTest(unittest.TestCase):
 
 
 @pytest.mark.parametrize("nmea", [
-    six.text_type(BARE_NMEA.strip()),
-    six.text_type(TAG_BLOCK.strip()),
-    six.text_type(USCG.strip()),
-    six.text_type(MIXED.strip())
+    BARE_NMEA.strip(),
+    TAG_BLOCK.strip(),
+    USCG.strip(),
+    MIXED.strip()
 ])
 def test_NmeaFile_against_queue(nmea):
 

--- a/test/testutils.py
+++ b/test/testutils.py
@@ -1,5 +1,4 @@
 import re
-import six
 
 known_bad = set((
     'addressed',
@@ -24,7 +23,7 @@ def TextToNumber(text):
 def IsNumber(value):
   if isinstance(value, float):
     return True
-  if isinstance(value, six.integer_types):
+  if isinstance(value, int):
     return True
   return False
 
@@ -49,10 +48,10 @@ def DictDiff(a, b):
       return True
     x = TextToNumber(x)
     y = TextToNumber(y)
-    if isinstance(x, six.string_types) and isinstance(y, six.string_types):
+    if isinstance(x, str) and isinstance(y, str):
       # Collapse strings to just lower case a-z to avoid simple mismatches.
-      new_x = re.sub(r'[^a-z]', r'', six.text_type(x).lower())
-      new_y = re.sub(r'[^a-z]', r'', six.text_type(y).lower())
+      new_x = re.sub(r'[^a-z]', r'', str(x).lower())
+      new_y = re.sub(r'[^a-z]', r'', str(y).lower())
       if new_x == new_y:
         return True
     if IsNumber(x) and IsNumber(y):

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -3,7 +3,6 @@
 
 import unittest
 from ais import util
-import six
 
 
 class UtilTest(unittest.TestCase):
@@ -25,7 +24,7 @@ class UtilTest(unittest.TestCase):
     value = 9999999999999999999999999
     value_str = '9999999999999999999999999'
     self.assertEqual(util.MaybeToNumber(value_str), value)
-    self.assertIsInstance(util.MaybeToNumber(value_str), six.integer_types)
+    self.assertIsInstance(util.MaybeToNumber(value_str), int)
 
     self.assertEqual(
         util.MaybeToNumber('1e99999999999999999999999'), float('inf'))

--- a/test/vdm_test.py
+++ b/test/vdm_test.py
@@ -5,7 +5,6 @@
 import unittest
 
 from ais import vdm
-import six
 
 
 class TestCase(unittest.TestCase):
@@ -82,8 +81,8 @@ class VdmLinesTest(unittest.TestCase):
         r'\g:3-3-42349,n:111460*1E\$',
     )
     generator = vdm.VdmLines(lines)
-    self.assertEqual(six.next(generator), '!AIVDM,2,2,2,B,00000000000,2*25')
-    self.assertRaises(StopIteration, six.next, generator)
+    self.assertEqual(next(generator), '!AIVDM,2,2,2,B,00000000000,2*25')
+    self.assertRaises(StopIteration, next, generator)
 
 
 class ParseTest(TestCase):


### PR DESCRIPTION
We no longer support python 2.x, so there is no need for a dependency on the `six` package.  Remove all references to six and replace with native python 3 functions